### PR TITLE
♿ Added alt-text on dark mode toggle

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -29,7 +29,7 @@
                 {{ config.extra.papermod.title }}
             </a>
             <div class="logo-switches">
-                <button id="theme-toggle" accesskey="t" title="(Alt + T)">
+                <button id="theme-toggle" accesskey="t" title="(Alt + T)" alt="Dark Mode Toggle">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
                         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                         stroke-linejoin="round">


### PR DESCRIPTION
Minor accessibility issue showing in Firefox's accessibility inspector: the dark mode button toggle was missing an `alt` attribute, making it difficult for screen reader users to know what it is doing.